### PR TITLE
feat: add prometheys

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,7 +32,11 @@ management:
   endpoints:
     web:
       exposure:
-        include: "*"
+        include: health,info,prometheus
+  metrics:
+    export:
+      prometheus:
+        enabled: true
   health:
     circuitbreakers:
       enabled: true


### PR DESCRIPTION
This pull request updates the application's configuration to restrict the exposed web endpoints and enable Prometheus metrics export. The most important changes are:

**Endpoint exposure and monitoring:**

* Restricted the `endpoints.web.exposure.include` setting to only expose the `health`, `info`, and `prometheus` endpoints instead of all endpoints.
* Enabled Prometheus metrics export by adding the `management.metrics.export.prometheus.enabled: true` configuration.